### PR TITLE
Automatically download all papers 

### DIFF
--- a/get_all_pdf_nips.py
+++ b/get_all_pdf_nips.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+"""
+Download all the pdfs linked on a given webpage
+Usage -
+    python grab_pdfs.py url <path/to/directory>
+        url is required
+        path is optional. Path needs to be absolute
+        will save in the current directory if no path is given
+        will save in the current directory if given path does not exist
+Requires - requests >= 1.0.4
+           beautifulsoup >= 4.0.0
+Download and install using
+    
+    pip install requests
+    pip install beautifulsoup4
+"""
+
+
+from requests import get
+from urllib.parse import urljoin
+from os import path, getcwd
+from bs4 import BeautifulSoup as soup
+
+
+"""
+Author: Avijit Dasgupta
+
+This script downloads all the pdf files of the accepted papers from "https://papers.nips.cc".
+
+To run this code: python get_all_pdf_nips.py year where you need to specify the year (e.g.- 2011, 2012 etc.)
+
+"""
+
+
+from sys import argv
+import pdb
+from bs4 import BeautifulSoup
+import pandas as pd
+import urllib
+import numpy as np
+import pdb
+import os
+import sys
+from nltk.tokenize import RegexpTokenizer
+from gensim import corpora, models
+import gensim
+from stop_words import get_stop_words
+import logging
+from nltk.corpus import stopwords
+from nltk.stem.wordnet import WordNetLemmatizer
+import string
+
+
+
+year = str(sys.argv[1])
+#year = str(2015)
+base_dir = "NIPS" + year
+if not os.path.exists(base_dir):
+    os.makedirs(base_dir)
+base_url = "https://papers.nips.cc"
+url= 'https://papers.nips.cc/book/advances-in-neural-information-processing-systems-29-'+year
+logging.info("Connecting to URL: %s" % url)
+page = urllib.request.urlopen(url)
+
+soup = BeautifulSoup(urllib.request.urlopen(url), "html.parser")
+lists = soup.find_all('li') # Title and paper url
+#print(len(lists))
+lists = lists[1:]
+n_pdfs = 0
+for paper_link in lists:
+    
+    print(paper_link.find_all('a')[0]['href'])
+    n_pdfs+= 1
+    content= get(urljoin(base_url, paper_link.find_all('a')[0]['href']+ '.pdf'))
+
+    with open(path.join(base_dir, paper_link.find_all('a')[0]['href'][7:]+'.pdf'), 'wb') as pdf: #remove /paper/
+        pdf.write(content.content)
+
+
+pdb.set_trace()

--- a/getallpdfnips.py
+++ b/getallpdfnips.py
@@ -1,26 +1,6 @@
 #!/usr/bin/env python
 
-"""
-Download all the pdfs linked on a given webpage
-Usage -
-    python grab_pdfs.py url <path/to/directory>
-        url is required
-        path is optional. Path needs to be absolute
-        will save in the current directory if no path is given
-        will save in the current directory if given path does not exist
-Requires - requests >= 1.0.4
-           beautifulsoup >= 4.0.0
-Download and install using
-    
-    pip install requests
-    pip install beautifulsoup4
-"""
 
-
-from requests import get
-from urllib.parse import urljoin
-from os import path, getcwd
-from bs4 import BeautifulSoup as soup
 
 
 """
@@ -33,6 +13,9 @@ To run this code: python get_all_pdf_nips.py year where you need to specify the 
 """
 
 
+from requests import get
+from urllib.parse import urljoin
+from os import path, getcwd
 from sys import argv
 import pdb
 from bs4 import BeautifulSoup

--- a/getallpdfnips.py
+++ b/getallpdfnips.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-
-
-
 """
 Author: Avijit Dasgupta
 
@@ -61,4 +58,4 @@ for paper_link in lists:
         pdf.write(content.content)
 
 
-pdb.set_trace()
+


### PR DESCRIPTION
This script contains a script which can be used to download all papers from NIPS' website for a particular year.

To run this code: `python get_all_pdf_nips.py year` where you need to specify the year (e.g.- 2011, 2012 etc.)